### PR TITLE
[xserver-xorg] Remove xf86-input-libinput from RRECOMMENDS

### DIFF
--- a/recipes-graphics/xorg-xserver/xserver-xorg_1.19.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_1.19.1.bbappend
@@ -1,0 +1,3 @@
+# we don't use this driver; don't build it
+RRECOMMENDS_${PN}_remove = "xf86-input-libinput"
+RRECOMMENDS_${PN}-xwayland_remove = "xf86-input-libinput"


### PR DESCRIPTION
Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>